### PR TITLE
feat(table_roles): Ajout de la table `roles` et seeding initial

### DIFF
--- a/fast_api_xtrem/app/application.py
+++ b/fast_api_xtrem/app/application.py
@@ -1,11 +1,8 @@
 """Module principal de l'application FastAPI."""
 
-import inspect
-import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator, Optional
 
-import uvicorn
 from fastapi import FastAPI
 
 from fast_api_xtrem.app.config import AppConfig
@@ -62,28 +59,3 @@ class Application:
         fastapi_app.state.logger = self.services.logger
         yield
         self.services.cleanup()
-
-    def run(self) -> None:
-        """Lance l'application avec uvicorn."""
-        if self.config.reload:
-            # Récupère dynamiquement le chemin du module pour rechargement
-            frame = inspect.stack()[1]
-            module_path: str = frame.filename
-            module_name: str = os.path.basename(module_path).replace(".py", "")
-            package_parts = __name__.split(".")
-            package_name: str = ".".join(package_parts[:-1])
-            app_import_string: str = f"{package_name}.{module_name}:app"
-
-            return uvicorn.run(
-                app_import_string,
-                host=self.config.network_config.host,
-                port=self.config.network_config.port,
-                reload=True,
-            )
-
-        return uvicorn.run(
-            self.fast_api,
-            host=self.config.network_config.host,
-            port=self.config.network_config.port,
-            reload=False,
-        )

--- a/fast_api_xtrem/db/models/role.py
+++ b/fast_api_xtrem/db/models/role.py
@@ -1,0 +1,26 @@
+"""
+Définit le modèle Role utilisé pour représenter les rôles d'utilisateurs
+dans la base de données.
+
+Chaque rôle possède un identifiant unique et un libellé
+"""
+
+from sqlalchemy import Column, Integer, String
+
+from fast_api_xtrem.db.base import Base
+
+
+# pylint: disable=too-few-public-methods
+class Role(Base):
+    """
+    Représente un rôle d'utilisateur dans la base de données.
+
+    Attributs :
+        id (int) : Identifiant unique du rôle.
+        libelle (str) : Nom ou libellé du rôle (ex. : "admin", "utilisateur").
+    """
+
+    __tablename__ = "roles"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    libelle = Column(String(50), nullable=False)

--- a/fast_api_xtrem/db/models/user.py
+++ b/fast_api_xtrem/db/models/user.py
@@ -15,16 +15,16 @@ class User(Base):
     """
     Représente un utilisateur dans la base de données.
 
-    Attributs:
-        id (int): Identifiant unique de l'utilisateur.
-        nom (str): Nom complet de l'utilisateur.
-        email (str): Adresse email de l'utilisateur.
-        pswd (str): Mot de passe de l'utilisateur (non chiffré ici).
+    Attributs :
+        id (int) : Identifiant unique de l'utilisateur.
+        nom (str) : Nom complet de l'utilisateur.
+        email (str) : Adresse email de l'utilisateur.
+        pswd (str) : Mot de passe de l'utilisateur (non chiffré ici).
     """
 
     __tablename__ = "users"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     nom = Column(String(50), nullable=False)
-    email = Column(String(50), nullable=False)
-    pswd = Column(String(50), nullable=False)
+    email = Column(String(100), nullable=False)
+    pswd = Column(String(100), nullable=False)

--- a/fast_api_xtrem/db/utils/utils.py
+++ b/fast_api_xtrem/db/utils/utils.py
@@ -1,0 +1,32 @@
+"""
+Module de peuplement initial (seeding) pour la base de données.
+
+Contient la fonction permettant d’insérer les rôles par défaut
+dans la table `roles` si ceux-ci n’existent pas encore.
+"""
+
+from sqlalchemy.orm import sessionmaker
+
+from fast_api_xtrem.db.models.role import Role
+
+
+def seed_default_roles(engine, logger):
+    """Alimente la table 'roles' si vide."""
+    session_factory = sessionmaker(bind=engine)
+    with session_factory() as session:
+        existing_roles = {r.libelle for r in session.query(Role).all()}
+        new_roles = []
+
+        for role in ["admin", "membre"]:
+            if role not in existing_roles:
+                new_roles.append(Role(libelle=role))
+                logger.info(f"Ajout du rôle : {role}")
+
+        if new_roles:
+            session.add_all(new_roles)
+            session.commit()
+            logger.success(
+                f"🎉 Rôles insérés : {', '.join(r.libelle for r in new_roles)}"
+            )
+        else:
+            logger.info("✅ Tous les rôles existent déjà")

--- a/fast_api_xtrem/main.py
+++ b/fast_api_xtrem/main.py
@@ -12,6 +12,7 @@ import os
 import sys
 
 from prometheus_fastapi_instrumentator import Instrumentator
+from uvicorn import run
 
 from fast_api_xtrem.app.application import Application
 from fast_api_xtrem.app.config import AppConfig
@@ -37,4 +38,7 @@ def create_app() -> Application:
 if __name__ == "__main__":
     app = create_app()
     Instrumentator().instrument(app.fast_api).expose(app.fast_api)
-    app.run()
+    # Lancement de l'application via Uvicorn
+    host = app.config.network_config.host
+    port = app.config.network_config.port
+    run(app.fast_api, host=host, port=port)


### PR DESCRIPTION
Création de la table `roles` pour gérer les rôles des utilisateurs.

Implémentation d'une fonction `seed_default_roles` pour insérer les rôles "admin" et "membre" par défaut lors de la création de la base de données.  Cette fonction vérifie l'existence préalable des rôles avant insertion pour éviter les doublons.

Amélioration de la gestion de la connexion à la base de données avec des vérifications supplémentaires et la fermeture explicite des sessions.

Le lancement de l'application est simplifié et utilise maintenant uvicorn directement dans le fichier main.py.